### PR TITLE
support external payout

### DIFF
--- a/src/concentrated-liquidity/CampaignCL.sol
+++ b/src/concentrated-liquidity/CampaignCL.sol
@@ -18,11 +18,13 @@ contract CampaignCL is RewardsUpdateCL, RewardsClaim {
         address owner,
         bytes32[] calldata vks,
         uint64 dataChainId,
-        address rewardUpdater
+        address rewardUpdater,
+        address externalPayoutAddress
     ) external {
         initOwner(owner);
         _initConfig(cfg, brv, vks, dataChainId);
         grantRole(REWARD_UPDATER_ROLE, rewardUpdater);
+        _setExternalPayoutAddress(externalPayoutAddress);
     }
 
     // ----- external functions -----
@@ -35,6 +37,10 @@ contract CampaignCL is RewardsUpdateCL, RewardsClaim {
             address erc20 = cfg.rewards[i].token;
             IERC20(erc20).safeTransfer(cfg.creator, IERC20(erc20).balanceOf(address(this)));
         }
+    }
+
+    function canRefund() external view returns (bool) {
+        return block.timestamp > config.startTime + config.duration + gracePeriod;
     }
 
     // ----- internal functions -----

--- a/src/generic/CampaignGeneric.sol
+++ b/src/generic/CampaignGeneric.sol
@@ -17,11 +17,13 @@ contract CampaignGeneric is RewardsUpdateGeneric, RewardsClaim {
         address owner,
         bytes32[] calldata vks,
         uint64 dataChainId,
-        address rewardUpdater
+        address rewardUpdater,
+        address externalPayoutAddress
     ) external {
         initOwner(owner);
         _initConfig(cfg, brv, vks, dataChainId);
         grantRole(REWARD_UPDATER_ROLE, rewardUpdater);
+        _setExternalPayoutAddress(externalPayoutAddress);
     }
 
     // ----- external functions -----
@@ -34,6 +36,10 @@ contract CampaignGeneric is RewardsUpdateGeneric, RewardsClaim {
             address erc20 = cfg.rewards[i].token;
             IERC20(erc20).safeTransfer(cfg.creator, IERC20(erc20).balanceOf(address(this)));
         }
+    }
+
+    function canRefund() external view returns (bool) {
+        return block.timestamp > config.startTime + config.duration + gracePeriod;
     }
 
     // ----- internal functions -----

--- a/src/rewards/cross-chain/CampaignRewardsClaim.sol
+++ b/src/rewards/cross-chain/CampaignRewardsClaim.sol
@@ -18,7 +18,8 @@ struct Config {
     uint64 startTime;
     uint32 duration; // how many seconds this campaign is active, end after startTime+duration
     AddrAmt[] rewards; // list of [reward token and total amount]
-    address externalPayoutAddress; // If nonzero, only this address can call claim and no transfer will be made
+    // If set, only this address can call claim; rewards are not transferred directly, external address handles payout.
+    address externalPayoutAddress;
 }
 
 // claim campaign rewards on chain one chain, which was submitted on another chain

--- a/src/rewards/same-chain/RewardsClaim.sol
+++ b/src/rewards/same-chain/RewardsClaim.sol
@@ -20,19 +20,22 @@ abstract contract RewardsClaim is RewardsStorage {
     // seconds after campaign end, after which all remaining balance can be refunded to creator
     uint64 public gracePeriod = 3600 * 24 * 180; // default 180 days
 
+    // If nonzero, only this address can call claim and no transfer will be made
+    address public externalPayoutAddress;
+
     event RewardsClaimed(address indexed earner, uint256[] claimedRewards);
     event GracePeriodUpdated(uint64 gracePeriod);
 
     // ----- external functions -----
 
     // claim reward, send erc20 to earner
-    function claim(address earner) external {
-        _claim(earner, earner);
+    function claim(address earner) external returns (address[] memory, uint256[] memory) {
+        return _claim(earner, earner);
     }
 
     // msg.sender is the earner
-    function claimWithRecipient(address to) external {
-        _claim(msg.sender, to);
+    function claimWithRecipient(address to) external returns (address[] memory, uint256[] memory) {
+        return _claim(msg.sender, to);
     }
 
     function viewUnclaimedRewards(address earner) external view returns (AddrAmt[] memory) {
@@ -52,7 +55,11 @@ abstract contract RewardsClaim is RewardsStorage {
 
     // ----- internal functions -----
 
-    function _claim(address earner, address to) internal {
+    function _setExternalPayoutAddress(address _externalPayoutAddress) internal {
+        externalPayoutAddress = _externalPayoutAddress;
+    }
+
+    function _claim(address earner, address to) internal returns (address[] memory, uint256[] memory) {
         uint256[] memory claimedRewards = new uint256[](tokens.length);
         bool hasUnclaimed = false;
         for (uint256 i = 0; i < tokens.length; i++) {
@@ -62,7 +69,11 @@ abstract contract RewardsClaim is RewardsStorage {
             claimed[earner][token] = cumulativeAmount;
             // send token
             if (tosend > 0) {
-                IERC20(token).safeTransfer(to, tosend);
+                if (externalPayoutAddress == address(0)) {
+                    IERC20(token).safeTransfer(to, tosend);
+                } else {
+                    require(msg.sender == externalPayoutAddress, "unauthorized caller");
+                }
                 tokenClaimedRewards[token] += tosend;
                 hasUnclaimed = true;
             }
@@ -70,5 +81,6 @@ abstract contract RewardsClaim is RewardsStorage {
         }
         require(hasUnclaimed, "no unclaimed rewards");
         emit RewardsClaimed(earner, claimedRewards);
+        return (tokens, claimedRewards);
     }
 }

--- a/src/rewards/same-chain/RewardsClaim.sol
+++ b/src/rewards/same-chain/RewardsClaim.sol
@@ -20,7 +20,7 @@ abstract contract RewardsClaim is RewardsStorage {
     // seconds after campaign end, after which all remaining balance can be refunded to creator
     uint64 public gracePeriod = 3600 * 24 * 180; // default 180 days
 
-    // If nonzero, only this address can call claim and no transfer will be made
+    // If set, only this address can call claim; rewards are not transferred directly, external address handles payout.
     address public externalPayoutAddress;
 
     event RewardsClaimed(address indexed earner, uint256[] claimedRewards);


### PR DESCRIPTION
In this mode, Incentra campaign contract does not hold reward tokens, it only maintain states, and let the externalPayout contract to actually distribute the reward token